### PR TITLE
🐛 Lazyload IscnCard to prevent importing p5 in server

### DIFF
--- a/components/IscnCard.vue
+++ b/components/IscnCard.vue
@@ -550,7 +550,7 @@ export default class IscnCard extends Vue {
       }
     }
 
-    if (!this.canvas) {
+    if (!this.canvas && window) {
       this.canvas = new P5(sketch, this.$refs.canvas as HTMLElement)
     }
 

--- a/components/IscnUploadedInfo.vue
+++ b/components/IscnUploadedInfo.vue
@@ -16,7 +16,7 @@
       />
       <!-- ISCN card -->
       <ClientOnly v-if="record">
-        <IscnCard
+        <LazyIscnCard
           class="mb-[16px]"
           :record="record"
           :is-animated="true"

--- a/components/SearchResult.vue
+++ b/components/SearchResult.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="w-min">
     <ClientOnly>
-      <IscnCard
+      <LazyIscnCard
         class="w-[220px] mb-[16px]"
         :record="record"
         orientation="portrait"

--- a/pages/embed/card/_iscnId.vue
+++ b/pages/embed/card/_iscnId.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="record">
     <ClientOnly>
-      <IscnCard v-bind="cardProps" />
+      <LazyIscnCard v-bind="cardProps" />
     </ClientOnly>
     <pre
       v-if="isShowAdjustableProps"

--- a/pages/view/_iscnId.vue
+++ b/pages/view/_iscnId.vue
@@ -23,7 +23,7 @@
     >
       <div class="mr-[32px]">
         <ClientOnly>
-          <IscnCard
+          <LazyIscnCard
             :key="record.id"
             class="w-[280px]"
             :record="record"


### PR DESCRIPTION
I encountered random `window is not defined` server error in test env, but cannot reliably reproduce
Just as a defensive method to lazy load iscn card components