### PR TITLE
🐛 Fix viewport setup

### DIFF
--- a/components/RootLayout.vue
+++ b/components/RootLayout.vue
@@ -34,16 +34,15 @@ const uiModule = namespace('ui')
 @Component({
   head() {
     const isDesktopViewMode: boolean = this.$store.getters['ui/isDesktopViewMode']
-    const contentWidth = isDesktopViewMode ? 'width=1024' : 'width=device-width'
+    const contentWidth = isDesktopViewMode
+      ? 'width=1024, initial-scale=1, minimum-scale=1'
+      : 'width=device-width'
 
     return {
       htmlAttrs: {
         class: this.$props.bgClass,
       },
-      meta: [
-        { charset: 'utf-8' },
-        { name: 'viewport', content: contentWidth },
-      ],
+      meta: [{ hid: 'viewport', name: 'viewport', content: contentWidth }],
     }
   },
 })

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -14,7 +14,7 @@ export default {
     title: 'ISCN App',
     meta: [
       { charset: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1, minimum-scale=1' },
+      { hid: 'viewport', name: 'viewport', content: 'width=device-width' },
       { hid: 'description', name: 'description', content: siteDefaultDescription },
       { hid: 'og:site_name', name: 'og:site_name', content: 'ISCN App'},
       { hid: 'og:title', property: 'og:title', content: 'ISCN App' },


### PR DESCRIPTION
Missing `hid` will cause 2 viewports in `<meta/>`