### PR TITLE
🐛 [/view/_iscnId] Fix page exceeds the screen

### DIFF
--- a/pages/view/_iscnId.vue
+++ b/pages/view/_iscnId.vue
@@ -53,6 +53,8 @@
   >
     <div
       :class="[
+        'relative',
+
         'flex',
         'lg:block',
 
@@ -65,7 +67,8 @@
         'max-w-full',
         'lg:max-w-[280px]',
         'lg:mr-[32px]',
-      ]">
+      ]"
+    >
       <ClientOnly>
         <LazyIscnCard
           :key="record.id"


### PR DESCRIPTION
Page exceeds 100% of screen high and width.

https://user-images.githubusercontent.com/75730405/152785614-4361627c-30fd-44a1-a8fd-43d42483cda3.mov



fix
![截圖 2022-02-07 下午7 45 05](https://user-images.githubusercontent.com/75730405/152784668-f4be2752-a525-4f54-8760-7d213d27be2d.png)

