### PR TITLE
🐛 Fix cannot display iscn id without version

### DIFF
--- a/pages/view/_iscnId.vue
+++ b/pages/view/_iscnId.vue
@@ -608,7 +608,10 @@ export default class ViewIscnIdPage extends Vue {
     this.getMintInfo()
     if (!this.getISCNById(this.iscnId) || !this.owner) {
       const res = await this.fetchISCNById(this.iscnId)
-      if (res) this.owner = res.owner
+      if (res) {
+        this.iscnId = res.records[0].id // To replace prefix with full id
+        this.owner = res.owner
+      }
     }
     if (!this.getISCNById(this.iscnId)) {
       this.$nuxt.error({ statusCode: 404, message: ErrorMessage.statusCode404 })


### PR DESCRIPTION
then we can just use an iscn prefix path to get latest iscn info