### PR TITLE
🔒️ Allow wasm-eval

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -58,6 +58,7 @@ export default {
         'script-src': [
           "'self'",
           "'unsafe-inline'", // ignored by browser with sha support
+          "'wasm-unsafe-eval'",
           "www.googletagmanager.com",
         ],
         'connect-src': [


### PR DESCRIPTION
Fixes CompileError: WebAssembly.instantiate(): Wasm code generation disallowed by embedder