### PR TITLE
♻️ Update iscn-js and add url and description when minting class

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@cosmjs/stargate": "^0.28.4",
-    "@likecoin/iscn-js": "^0.2.0-rc.1",
+    "@likecoin/iscn-js": "^0.2.1",
     "@likecoin/iscn-message-types": "^0.0.3",
     "@nuxtjs/axios": "^5.13.6",
     "@nuxtjs/i18n": "^7.0.1",

--- a/pages/nft/iscn/_iscnId.vue
+++ b/pages/nft/iscn/_iscnId.vue
@@ -446,6 +446,8 @@ export default class NFTTestMintPage extends Vue {
             nft_meta_collection_name: 'Writing NFT',
             nft_meta_collection_descrption: 'Writing NFT by Liker Land',
             image: this.ogImageUri,
+            description: this.iscnData.contentMetadata?.description,
+            external_url: this.iscnData.contentMetadata?.url,
           },
         },
       )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1922,22 +1922,17 @@
     methods "^1.1.2"
     path-to-regexp "^6.1.0"
 
-"@likecoin/iscn-js@^0.2.0-rc.1":
-  version "0.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@likecoin/iscn-js/-/iscn-js-0.2.0-rc.1.tgz#f89a9f9899369000359099c1d1e8aa1ba4a20987"
-  integrity sha512-sKFgoWmqo5AopVP+30kNc6ubjNVeaMFm+UZl85pAE6CDqIhBtEvnsaq7ml005JchisSTryzomQ42wM++Z8Jn9A==
+"@likecoin/iscn-js@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@likecoin/iscn-js/-/iscn-js-0.2.1.tgz#bab4c00aa10ff8d09714357b652dd9eaae0fd8a4"
+  integrity sha512-rXSanM0xsshD2DSMrj6466zhzFVmZ11r8VK+84xBoLC4GWJDqdG8bCheHrQkmJQz1iWxk3eQTQRf8EppzxKe2Q==
   dependencies:
-    "@likecoin/iscn-message-types" "0.0.3-rc.1"
+    "@likecoin/iscn-message-types" "0.0.3"
     bignumber.js "^9.0.1"
     buffer "^6.0.3"
     fast-json-stable-stringify "^2.1.0"
 
-"@likecoin/iscn-message-types@0.0.3-rc.1":
-  version "0.0.3-rc.1"
-  resolved "https://registry.yarnpkg.com/@likecoin/iscn-message-types/-/iscn-message-types-0.0.3-rc.1.tgz#70ef972f16dd3cb0713013b9fe21e05ea730ac70"
-  integrity sha512-shWRi1DZ8WWRsZCVTsf17MNvCAEdy4v5eYAcZjOcmA8w7RyXIr70ol+AMT468JBszbMQgPOIfOyxxado+SM2xA==
-
-"@likecoin/iscn-message-types@^0.0.3":
+"@likecoin/iscn-message-types@0.0.3", "@likecoin/iscn-message-types@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@likecoin/iscn-message-types/-/iscn-message-types-0.0.3.tgz#7d14a832b0a65dca039d697dbbdeb5db6b5f50e0"
   integrity sha512-kyjyLWfUyffTqKY+Jkw2FjFgN8uu5VGB2hvk9ipKNLw6cHzKbLOQadFuzw6vxX1nbF81oYC5JsDpd5xR23YrSA==


### PR DESCRIPTION
iscn-js 0.2.0-rc version auto injects all iscn info into class, 0.2.1 removes this and reduces gas needed
A further update to iscn-js would calculate gas used according to tx size instead of hardcode