### PR TITLE
🐛 Fix airdrop claim redirect path

### DIFF
--- a/pages/airdrop/check.vue
+++ b/pages/airdrop/check.vue
@@ -148,7 +148,7 @@ import {
     } as MetaInfo
   },
   fetch({ redirect }) {
-    redirect('airdrop/claim')
+    redirect('claim')
   },
 })
 export default class AirdropCheckPage extends Vue {


### PR DESCRIPTION
now it goes to `/airdrop/airdrop/claim`