### PR TITLE
🐛 Handle un/encoded url in crawler api

### DIFF
--- a/pages/nft/url/index.vue
+++ b/pages/nft/url/index.vue
@@ -149,6 +149,12 @@ export default class FetchIndex extends Vue {
     return this.url.startsWith('iscn://likecoin-chain')
   }
 
+  get encodedURL(): string {
+    const { url } = this;
+    if (decodeURI(url) !== url) return url;
+    return encodeURI(url);
+  }
+
   get formData(): FormData | null {
     if (!this.crawledData?.body) { return null }
     const body = new Blob([this.crawledData.body], { type: "text/html" })
@@ -316,7 +322,7 @@ export default class FetchIndex extends Vue {
   async crawlUrlData() {
     try {
       logTrackerEvent(this, 'NFTUrlMint', 'CrawlUrlData', this.url, 1);
-      const { data } = await this.$axios.get(`/crawler/?url=${encodeURIComponent(this.url)}`)
+      const { data } = await this.$axios.get(`/crawler/?url=${encodeURIComponent(this.encodedURL)}`)
       this.crawledData = data
       if (!this.crawledData?.body) { throw new Error('CANNOT_CRAWL_THIS_URL') }
       if (this.crawledData?.title === 'patreon.com' && this.crawledData?.description === '') { throw new Error('SITE_NOT_CRAWLABLE: pateron') }

--- a/server/crawler/index.ts
+++ b/server/crawler/index.ts
@@ -207,7 +207,7 @@ async function getBrowser(): Promise<any> {
 async function getContentFromUrl(url: string) {
   let content
   try {
-    const { data } = await axios.get(encodeURI(url as string))
+    const { data } = await axios.get(url)
     content = data
   } catch (error: any) {
     if (error?.response?.status === 403) {

--- a/server/crawler/router.ts
+++ b/server/crawler/router.ts
@@ -6,10 +6,13 @@ const router = Router()
 
 router.get('/', async (req, res, next) => {
   try {
-    const { url } = req.query
+    let { url } = req.query
     if (!url) {
       res.status(400).send('MISSING_URL')
       return
+    }
+    if (decodeURI(url) === url) {
+      url = encodeURI(url);
     }
     const data = await getCralwerData(url as string)
     res.send(data)


### PR DESCRIPTION
it is hard to know if a string is encoded or not, but let's assume a unencoded string changes on `decode()`