### PR TITLE
🐛 Guard creator message by byte length

### DIFF
--- a/components/EditableForm.vue
+++ b/components/EditableForm.vue
@@ -51,7 +51,12 @@
           />
         </FormField>
 
-        <Button class="ml-auto" preset="secondary" @click="handleClickConfirm">
+        <Button
+          :is-disabled="errorMessage"
+          class="ml-auto"
+          :preset="errorMessage ? 'tertiary' : 'secondary'"
+          @click="handleClickConfirm"
+        >
           {{ $t('UploadForm.button.confirm') }}
         </Button>
       </ContentCard>
@@ -66,6 +71,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator'
 export default class UploadForm extends Vue {
   @Prop(Number) readonly step: number | undefined
   @Prop(String) readonly placeholder: string | undefined
+  @Prop({ default: 256 }) readonly maxLength: number | undefined
 
   isOpenDialog: boolean = false
   message: string = ''
@@ -78,10 +84,10 @@ export default class UploadForm extends Vue {
   }
 
   get errorMessage() {
-    if (this.message.length > 256) {
+    if (this.maxLength && Buffer.byteLength(this.messageInput, 'utf8') > this.maxLength) {
       return this.$t('IscnRegisterForm.warning.exceeded', {
-        current: this.message.length,
-        limit: 256,
+        current: Buffer.byteLength(this.messageInput, 'utf8'),
+        limit: this.maxLength,
       })
     }
     return undefined


### PR DESCRIPTION
The confirm button cannot be clicked if the message byte length is exceeded.

![截圖 2022-11-29 下午12 48 46](https://user-images.githubusercontent.com/75730405/204443424-393b843a-9105-4918-b23d-11de07460d7d.png)

