### PR TITLE
🚸 Use session storage to prevent mobile stuck in desktop mode

### DIFF
--- a/store/ui.ts
+++ b/store/ui.ts
@@ -33,16 +33,16 @@ export default class UIStore extends VuexModule {
   init() {
     let mode: any = ''
     mode =
-      window.localStorage?.getItem(CURRENT_VIEW_MODE_KEY) === ViewMode.Desktop ||
+      window.sessionStorage?.getItem(CURRENT_VIEW_MODE_KEY) === ViewMode.Desktop ||
       ViewMode.Mobile
-        ? window.localStorage?.getItem(CURRENT_VIEW_MODE_KEY)
+        ? window.sessionStorage?.getItem(CURRENT_VIEW_MODE_KEY)
         : ViewMode.Mobile
     this.setViewMode(mode)
   }
 
   @Action
   changeViewMode(mode: ViewMode) {
-    window.localStorage?.setItem(CURRENT_VIEW_MODE_KEY, mode)
+    window.sessionStorage?.setItem(CURRENT_VIEW_MODE_KEY, mode)
     this.setViewMode(mode)
   }
 


### PR DESCRIPTION
I think switching to desktop mode need not and should not persist in local storage
Now a mobile user would stuck in a blank screen if wallet connect is triggered in desktop mode