### PR TITLE
🚸 Store pagination and use same window for work/search result

### DIFF
--- a/components/SearchResults.vue
+++ b/components/SearchResults.vue
@@ -10,7 +10,6 @@
           name: 'view-iscnId',
           params: { iscnId: record.id },
         })"
-        target="_blank"
       >
         <SearchResult :record="record" />
       </NuxtLink>

--- a/pages/search/_keyword.vue
+++ b/pages/search/_keyword.vue
@@ -38,7 +38,7 @@
           size="small"
           :text="$t('WorksPage.pagination.button.first')"
           :is-disabled="pageNumber === 0"
-          @click="pageNumber = 0"
+          @click="firstPage"
         />
         <Button
           class="text-dark-gray"
@@ -86,13 +86,14 @@
           size="small"
           :text="$t('WorksPage.pagination.button.last')"
           :is-disabled="pageNumber >= pages.length - 1"
-          @click="pageNumber = pages.length - 1"
+          @click="lastPage"
         />
       </div>
     </nav>
     <div class="mb-[40px]">
       <Transition name="works-grid" mode="out-in">
         <SearchResults
+          v-if="pages[pageNumber]"
           :key="pages[pageNumber][0].id"
           :records="pages[pageNumber]"
         />
@@ -143,7 +144,7 @@ export default class SearchPage extends Vue {
       keyword?: string, 
   }) => ISCNRecordWithID[] | PromiseLike<ISCNRecordWithID[]>
 
-  pageNumber = 0
+  pageNumber = Number(this.$route.query.page) || 0
   closeWarning = false
 
   get queryAllTerm(): string {
@@ -200,10 +201,30 @@ export default class SearchPage extends Vue {
 
   nextPage() {
     this.pageNumber = Math.min(this.pageNumber + 1, this.pages?.length || 1 - 1)
+    this.$router.replace({
+      query: { ...this.$route.query, page: this.pageNumber.toString() },
+    });
   }
 
   previousPage() {
     this.pageNumber = Math.max(this.pageNumber - 1, 0)
+    this.$router.replace({
+      query: { ...this.$route.query, page: this.pageNumber.toString() },
+    });
+  }
+
+  firstPage() {
+    this.pageNumber = 0
+    this.$router.replace({
+      query: { ...this.$route.query, page: this.pageNumber.toString() },
+    });
+  }
+
+  lastPage() {
+    this.pageNumber = this.pages.length - 1
+    this.$router.replace({
+      query: { ...this.$route.query, page: this.pageNumber.toString() },
+    });
   }
 
   handleWarningClose() {

--- a/pages/search/_keyword.vue
+++ b/pages/search/_keyword.vue
@@ -170,6 +170,13 @@ export default class SearchPage extends Vue {
     this.search()
   }
 
+  @Watch('pageNumber')
+  onPageNumberChanged() {
+    this.$router.replace({
+      query: { ...this.$route.query, page: this.pageNumber.toString() },
+    });
+  }
+
   async search(){
     logTrackerEvent(this, 'ISCNSearch', 'ISCNSearchResult', this.queryAllTerm, 1)
     if (this.queryAllTerm)  {
@@ -201,30 +208,18 @@ export default class SearchPage extends Vue {
 
   nextPage() {
     this.pageNumber = Math.min(this.pageNumber + 1, this.pages?.length || 1 - 1)
-    this.$router.replace({
-      query: { ...this.$route.query, page: this.pageNumber.toString() },
-    });
   }
 
   previousPage() {
     this.pageNumber = Math.max(this.pageNumber - 1, 0)
-    this.$router.replace({
-      query: { ...this.$route.query, page: this.pageNumber.toString() },
-    });
   }
 
   firstPage() {
     this.pageNumber = 0
-    this.$router.replace({
-      query: { ...this.$route.query, page: this.pageNumber.toString() },
-    });
   }
 
   lastPage() {
     this.pageNumber = this.pages.length - 1
-    this.$router.replace({
-      query: { ...this.$route.query, page: this.pageNumber.toString() },
-    });
   }
 
   handleWarningClose() {

--- a/pages/works/index.vue
+++ b/pages/works/index.vue
@@ -30,7 +30,7 @@
           size="small"
           :text="$t('WorksPage.pagination.button.first')"
           :is-disabled="pageNumber === 0"
-          @click="pageNumber = 0"
+          @click="firstPage"
         />
         <Button
           class="text-dark-gray"
@@ -73,7 +73,7 @@
           size="small"
           :text="$t('WorksPage.pagination.button.last')"
           :is-disabled="pageNumber >= pages.length - 1"
-          @click="pageNumber = pages.length - 1"
+          @click="lastPage"
         />
       </div>
     </nav>
@@ -82,6 +82,7 @@
       mode="out-in"
     >
       <SearchResults
+        v-if="pages[pageNumber]"
         :key="pages[pageNumber][0].id"
         :records="pages[pageNumber]"
       />
@@ -101,7 +102,7 @@ const iscnModule = namespace('iscn')
   layout: 'wallet',
 })
 export default class WorksIndexPageextends extends Vue {
-  pageNumber = 0
+  pageNumber = Number(this.$route.query.page) || 0
 
   @signerModule.Getter('getAddress') currentAddress!: string
   @iscnModule.Getter('getISCNChunks') recordChunks!: ISCNRecordWithID[][]
@@ -131,10 +132,30 @@ export default class WorksIndexPageextends extends Vue {
 
   nextPage() {
     this.pageNumber = Math.min(this.pageNumber + 1, this.pages?.length || 1 - 1)
+    this.$router.replace({
+      query: { ...this.$route.query, page: this.pageNumber.toString() },
+    });
   }
 
   previousPage() {
     this.pageNumber = Math.max(this.pageNumber - 1, 0)
+    this.$router.replace({
+      query: { ...this.$route.query, page: this.pageNumber.toString() },
+    });
+  }
+
+  firstPage() {
+    this.pageNumber = 0
+    this.$router.replace({
+      query: { ...this.$route.query, page: this.pageNumber.toString() },
+    });
+  }
+
+  lastPage() {
+    this.pageNumber = this.pages.length - 1
+    this.$router.replace({
+      query: { ...this.$route.query, page: this.pageNumber.toString() },
+    });
   }
 }
 </script>

--- a/pages/works/index.vue
+++ b/pages/works/index.vue
@@ -116,6 +116,13 @@ export default class WorksIndexPageextends extends Vue {
     this.refreshWorks()
   }
 
+  @Watch('pageNumber')
+  onPageNumberChanged() {
+    this.$router.replace({
+      query: { ...this.$route.query, page: this.pageNumber.toString() },
+    });
+  }
+
   mounted() {
     this.refreshWorks()
   }
@@ -132,30 +139,18 @@ export default class WorksIndexPageextends extends Vue {
 
   nextPage() {
     this.pageNumber = Math.min(this.pageNumber + 1, this.pages?.length || 1 - 1)
-    this.$router.replace({
-      query: { ...this.$route.query, page: this.pageNumber.toString() },
-    });
   }
 
   previousPage() {
     this.pageNumber = Math.max(this.pageNumber - 1, 0)
-    this.$router.replace({
-      query: { ...this.$route.query, page: this.pageNumber.toString() },
-    });
   }
 
   firstPage() {
     this.pageNumber = 0
-    this.$router.replace({
-      query: { ...this.$route.query, page: this.pageNumber.toString() },
-    });
   }
 
   lastPage() {
     this.pageNumber = this.pages.length - 1
-    this.$router.replace({
-      query: { ...this.$route.query, page: this.pageNumber.toString() },
-    });
   }
 }
 </script>


### PR DESCRIPTION
Store pagination in qs to allow backing to same search/work page state from view page