### PR TITLE
🐛 Fix mint & reserve amount focus

### DIFF
--- a/components/NFTMint/WriterMessage.vue
+++ b/components/NFTMint/WriterMessage.vue
@@ -96,13 +96,13 @@
             <span class="text-medium-gray">{{ `(${1} - ${maxMintAmount})` }}</span>
           </span>
           <TextField
-            :key="mintAmount.toString()"
             :value="mintAmount"
             type="number"
             :max="maxMintAmount"
             :min="1"
             :size="40"
             @input="updateMintAmount($event)"
+            @blur="handleMintAmountInputBlur"
           />
         </div>
         <div class="flex justify-between gap-[12px] text-dark-gray text-[14px] items-center">
@@ -111,13 +111,13 @@
             <span class="text-medium-gray">{{ `(${0} - ${mintAmount})` }}</span>
           </span>
           <TextField
-            :key="reserveAmount.toString()"
             :value="reserveAmount"
             type="number"
             :max="mintAmount"
             :min="0"
             :size="40"
             @input="updateReserveAmount($event)"
+            @blur="handleReserveAmountInputBlur"
           />
         </div>
       </div>
@@ -214,6 +214,14 @@ export default class WriterMessage extends Vue {
       // eslint-disable-next-line no-console
       console.error(err)
     }
+  }
+
+  handleMintAmountInputBlur() {
+    this.updateMintAmount(this.mintAmount)
+  }
+
+  handleReserveAmountInputBlur() {
+    this.updateReserveAmount(this.reserveAmount)
   }
 
   onClickReserveDefault() {

--- a/components/TextFieldList.vue
+++ b/components/TextFieldList.vue
@@ -13,7 +13,7 @@
         :size="40"
         :class="['my-[4px]', 'flex-grow']"
         :placeholder="placeholder"
-        @delete-empty-field="deleteEmptyField"
+        @blur="deleteEmptyField"
       />
       <span
         v-if="value.length > 1"

--- a/components/WalletFieldList.vue
+++ b/components/WalletFieldList.vue
@@ -77,7 +77,7 @@
         :class="['my-[4px]', 'flex-grow']"
         :size="40"
         :placeholder="getWalletAddressPlaceholder(item.type)"
-        @delete-empty-field="deleteEmptyField"
+        @blur="deleteEmptyField"
       />
       <span
         v-if="value.length > 1"


### PR DESCRIPTION
The issue is due to adding `key` prop force `<input>` to  be blur

Turns out updating the value prop of `<input/>` doesn't update the inner value of `<input/>`
So, I have to add a watcher for `<TextField/>` `value` prop and update the `<input/>` value
