### PR TITLE
🐛 Set default initial batch to 4 (128 LIKE)

### DIFF
--- a/pages/nft/iscn/_iscnId.vue
+++ b/pages/nft/iscn/_iscnId.vue
@@ -263,7 +263,7 @@ export default class NFTTestMintPage extends Vue {
 
   reserveNft: number = 0
   mintAmount: number = this.maxMintAmount
-  initialBatch: number = 0
+  initialBatch: number = 4
   shouldShowNoUrlWarning: boolean = false
 
   get isUserISCNOwner(): boolean {


### PR DESCRIPTION
Fix #380.
The update won't be triggered if the initial price setting component remains untouched.