### PR TITLE
[TAS-800] 🎨 Remove the retry action when opening Keplr

### DIFF
--- a/components/IscnRegisterForm.vue
+++ b/components/IscnRegisterForm.vue
@@ -1326,11 +1326,6 @@ export default class IscnRegisterForm extends Vue {
   onOpenKeplr() {
     logTrackerEvent(this, 'ISCNCreate', 'OpenKeplr', '', 1);
     this.isOpenKeplr = true
-    // Hack: In some cases, there might be no response from Keplr,
-    // so we set a timeout to automatically close it after 5 seconds.
-    setTimeout(() => {
-      this.isOpenKeplr = false
-    }, 5000)
   }
 
   validateField(


### PR DESCRIPTION
Since registering ISCN is now split into two steps, there's no need to set a 5s timeout for the re-open bug anymore.
so the retry button will no longer be affected by the reset of `isOpenKeplr`.