### PR TITLE
[TAS-954] 🩹 Increase gas multiplier for updating ISCN

### DIFF
--- a/constant/index.ts
+++ b/constant/index.ts
@@ -18,6 +18,7 @@ export const ISCN_MIN_BALANCE = 0.01;
 
 export const ISCN_GAS_FEE = 200000;
 export const ISCN_GAS_MULTIPLIER = 1.5;
+export const UPDATE_ISCN_GAS_MULTIPLIER = 1.75;
 
 export const ISCN_REGISTRY_NAME = 'likecoin-chain';
 

--- a/pages/edit/_iscnId.vue
+++ b/pages/edit/_iscnId.vue
@@ -238,7 +238,8 @@
 import { Vue, Component } from 'vue-property-decorator'
 import { namespace } from 'vuex-class'
 import { OfflineSigner } from '@cosmjs/proto-signing'
-import { ISCN_PREFIX } from '~/constant'
+import { BigNumber } from 'bignumber.js';
+import { ISCN_PREFIX, ISCN_GAS_FEE, UPDATE_ISCN_GAS_MULTIPLIER } from '~/constant'
 import { logTrackerEvent } from '~/utils/logger'
 import { signISCN } from '~/utils/cosmos/iscn/sign'
 import { extractIscnIdPrefix } from '~/utils/ui'
@@ -428,6 +429,7 @@ export default class EditIscnPage extends Vue {
       await this.initIfNecessary()
       const result = await signISCN(this.payload, this.signer, this.address, {
         iscnId: this.iscnId,
+        gas: new BigNumber(ISCN_GAS_FEE).multipliedBy(UPDATE_ISCN_GAS_MULTIPLIER).toFixed(0),
       })
       if (result) {
         this.$router.replace(

--- a/utils/cosmos/iscn/sign.ts
+++ b/utils/cosmos/iscn/sign.ts
@@ -5,7 +5,7 @@ import network from '@/constant/network';
 import { DeliverTxResponse } from '@cosmjs/stargate';
 import { BigNumber } from 'bignumber.js';
 import { ISCNRegisterPayload } from './iscn.type';
-import { WALLET_TYPE_REPLACER, ISCN_GAS_FEE, DEFAULT_GAS_PRICE, ISCN_GAS_MULTIPLIER } from '~/constant'
+import { WALLET_TYPE_REPLACER, ISCN_GAS_FEE, DEFAULT_GAS_PRICE, UPDATE_ISCN_GAS_MULTIPLIER } from '~/constant'
 import { getPublisherISCNPayload } from '.';
 import { ISCN_PUBLISHERS } from '~/constant/iscn';
 
@@ -159,7 +159,7 @@ export async function signISCN(
   {
     iscnId,
     memo,
-    gas = new BigNumber(ISCN_GAS_FEE).multipliedBy(ISCN_GAS_MULTIPLIER).toFixed(0),
+    gas = new BigNumber(ISCN_GAS_FEE).multipliedBy(UPDATE_ISCN_GAS_MULTIPLIER).toFixed(0),
   }: { iscnId?: string, memo?: string, gas?: string } = {},
 ) {
   const isUpdate = !!iscnId

--- a/utils/cosmos/iscn/sign.ts
+++ b/utils/cosmos/iscn/sign.ts
@@ -5,7 +5,7 @@ import network from '@/constant/network';
 import { DeliverTxResponse } from '@cosmjs/stargate';
 import { BigNumber } from 'bignumber.js';
 import { ISCNRegisterPayload } from './iscn.type';
-import { WALLET_TYPE_REPLACER, ISCN_GAS_FEE, DEFAULT_GAS_PRICE, UPDATE_ISCN_GAS_MULTIPLIER } from '~/constant'
+import { WALLET_TYPE_REPLACER, ISCN_GAS_FEE, DEFAULT_GAS_PRICE, ISCN_GAS_MULTIPLIER } from '~/constant'
 import { getPublisherISCNPayload } from '.';
 import { ISCN_PUBLISHERS } from '~/constant/iscn';
 
@@ -159,7 +159,7 @@ export async function signISCN(
   {
     iscnId,
     memo,
-    gas = new BigNumber(ISCN_GAS_FEE).multipliedBy(UPDATE_ISCN_GAS_MULTIPLIER).toFixed(0),
+    gas = new BigNumber(ISCN_GAS_FEE).multipliedBy(ISCN_GAS_MULTIPLIER).toFixed(0),
   }: { iscnId?: string, memo?: string, gas?: string } = {},
 ) {
   const isUpdate = !!iscnId


### PR DESCRIPTION
Even though the multiplier has been used and iscn-js updated, the wanted gas fee for updating ISCN is still slightly insufficient.
Therefore, I increased the multiplier from 1.5 to 1.75

![截圖 2024-01-24 晚上8 01 56](https://github.com/likecoin/app-like-co/assets/75730405/f97a55d9-6453-4182-a152-d6a6baafbcb9)
