### PR TITLE
[TAS-1216] ✨ Define book cover for PDF file

### DIFF
--- a/components/IscnRegisterForm.vue
+++ b/components/IscnRegisterForm.vue
@@ -1067,12 +1067,12 @@ export default class IscnRegisterForm extends Vue {
     this.uploadStatus = 'loading'
 
     if (this.epubMetadata) {
-      this.name = this.epubMetadata.title
+      this.name = this.epubMetadata.title || ''
       this.description = this.extractText(this.epubMetadata.description)
-      this.author.name = this.epubMetadata.author
+      this.author.name = this.epubMetadata.author || ''
       this.author.authorDescription = 'Author'
-      this.language = this.epubMetadata.language
-      this.tags = this.epubMetadata.tags
+      this.language = this.epubMetadata.language || ''
+      this.tags = this.epubMetadata.tags || []
       this.thumbnailUrl = this.formatArweave(
         this.epubMetadata.thumbnailArweaveId,
       ) as string

--- a/components/IscnUploadForm.vue
+++ b/components/IscnUploadForm.vue
@@ -836,8 +836,9 @@ export default class IscnUploadForm extends Vue {
     if (this.epubMetadataList?.find(epubMetadata => epubMetadata.thumbnailArweaveId)) {
       return;
     }
-    // eslint-disable-next-line no-restricted-syntax
-    for (const file of this.fileRecords) {
+
+    for (let i = 0; i < this.fileRecords.length; i += 1) {
+      const file = this.fileRecords[i]
       if (IMAGE_MIME_TYPES.includes(file.fileType)) {
         const existingData =
           this.sentArweaveTransactionInfo.get(file.ipfsHash) || {}
@@ -848,10 +849,10 @@ export default class IscnUploadForm extends Vue {
           })
           return
         }
-        let {transactionHash} = existingData;
+        let { transactionHash } = existingData
         if (!transactionHash) {
           // eslint-disable-next-line no-await-in-loop
-          transactionHash = await this.sendArweaveFeeTx(file);
+          transactionHash = await this.sendArweaveFeeTx(file)
         }
         // eslint-disable-next-line no-await-in-loop
         const arweaveId = await this.uploadFileAndGetArweaveId(
@@ -864,7 +865,10 @@ export default class IscnUploadForm extends Vue {
             thumbnailIpfsHash: file.ipfsHash,
             thumbnailArweaveId: arweaveId,
           })
-          this.sentArweaveTransactionInfo.set(file.ipfsHash, { transactionHash, arweaveId });
+          this.sentArweaveTransactionInfo.set(file.ipfsHash, {
+            transactionHash,
+            arweaveId,
+          })
           return
         }
         return

--- a/components/IscnUploadForm.vue
+++ b/components/IscnUploadForm.vue
@@ -765,6 +765,8 @@ export default class IscnUploadForm extends Vue {
       // TODO: Handle error
       // eslint-disable-next-line no-console
       console.error(err);
+    } finally {
+      this.uploadStatus = 'uploading';
     }
     return '';
   }

--- a/components/IscnUploadForm.vue
+++ b/components/IscnUploadForm.vue
@@ -847,7 +847,7 @@ export default class IscnUploadForm extends Vue {
             thumbnailIpfsHash: file.ipfsHash,
             thumbnailArweaveId: existingData.arweaveId,
           })
-          return
+          break
         }
         let { transactionHash } = existingData
         if (!transactionHash) {
@@ -869,9 +869,8 @@ export default class IscnUploadForm extends Vue {
             transactionHash,
             arweaveId,
           })
-          return
+          break
         }
-        return
       }
     }
   }


### PR DESCRIPTION
When a user uploads a PDF and a JPG/PNG image simultaneously, the first uploaded image should be set as the default cover image and written into the ISCN's thumbnail field.

QA flow:

1. Navigate to /new to register an ISCN.
2. Upload a PDF and an image.
3. Complete the registration process.
4. Verify in the downloaded JSON file if the thumbnail field has been populated.
