### PR TITLE
🔧 Fix authcore referrer issue

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -152,6 +152,10 @@ export default {
     'portal-vue/nuxt',
   ],
 
+  helmet: {
+    referrerPolicy: { policy: 'strict-origin' },
+  },
+
   // Axios module configuration: https://go.nuxtjs.dev/config-axios
   axios: {
     browserBaseURL: '/api',


### PR DESCRIPTION
authcore requires `document.referrer` exists in iframe to work
referrer policy cannot be `no-referrer`